### PR TITLE
Allow `TestFacility` to use `Promise`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Support `PromiseLike`, by [@compulim](https://github.com/compulim), in PR [#6](https://github.com/testduet/given-when-then/pull/6)
+- Support `PromiseLike`, by [@compulim](https://github.com/compulim), in PR [#6](https://github.com/testduet/given-when-then/pull/6) and [#XXX](https://github.com/testduet/given-when-then/pull/XXX)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Support `PromiseLike`, by [@compulim](https://github.com/compulim), in PR [#6](https://github.com/testduet/given-when-then/pull/6) and [#XXX](https://github.com/testduet/given-when-then/pull/XXX)
+- Support `PromiseLike`, by [@compulim](https://github.com/compulim), in PR [#6](https://github.com/testduet/given-when-then/pull/6) and [#7](https://github.com/testduet/given-when-then/pull/7)
 
 ### Changed
 


### PR DESCRIPTION
## Changelog

> Please copy and paste new entries from `CHANGELOG.md` here.

### Added

- Support `PromiseLike`, by [@compulim](https://github.com/compulim), in PR [#6](https://github.com/testduet/given-when-then/pull/6) and [#7](https://github.com/testduet/given-when-then/pull/7)

## Specific changes

> Please list each individual specific change in this pull request.

- Allow `TestFacility` to use `Promise` for a broader support of test facility